### PR TITLE
Fix versionbot's changelog mess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,13 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## v4.0.1 - 2017-11-21
-
 ## v4.1.0 - 2017-11-28
 
 * Upgrade to reconfix 0.0.4 to fix windows support [Tim Perry]
 * Make .configure() configure network settings for both 1.x & 2.x [Tim Perry]
 * Upgrade to resin-image-fs@4, adding ext support [Tim Perry]
+
+## v4.0.1 - 2017-11-21
 
 - Move from travis to circle and set up npm autopublishing
 


### PR DESCRIPTION
See https://github.com/resin-io-modules/resin-procbots/issues/348 - versionbot and I had a disagreement in #25, and now I need to patch things up.

I'm planning to merge this directly to master, once reviewed, and then tag it myself with the correct version, which should get everybody back on the same page.