### PR TITLE
Update resin-semver to support balenaOS version strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "resin-device-operations": "^1.4.1",
     "resin-image-fs": "^5.0.4",
     "resin-sdk-preconfigured": "^6.0.0",
-    "resin-semver": "^1.3.0",
+    "resin-semver": "^1.4.0",
     "rindle": "^1.3.0",
     "string-to-stream": "^1.0.1"
   }


### PR DESCRIPTION
This repo is one of the 16 repos identified to use/require a [resin-semver](https://github.com/resin-io-modules/resin-semver) version older than 1.4.0. See also:
* [Trello card](https://trello.com/c/11ZJfEv6/114-update-repos-that-depend-on-resin-semver)
* [Flowdock thread](https://www.flowdock.com/app/rulemotion/namechange/threads/lS-o4xF4qMvf-o2rAtdrqaZEPhs)